### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/src/server/static.ts
+++ b/src/server/static.ts
@@ -13,9 +13,16 @@ const mimeTypes: { [key: string]: string | undefined } = {
 };
 
 export const handle = (dir: string) => (requestUrl: UrlWithParsedQuery, _request: http.IncomingMessage, response: http.ServerResponse) => {
-  const filePath = path.join(dir, !requestUrl.pathname || requestUrl.pathname === "/"
+  let filePath = path.join(dir, !requestUrl.pathname || requestUrl.pathname === "/"
     ? "index.html"
     : requestUrl.pathname);
+
+  filePath = path.resolve(filePath);
+  if (!filePath.startsWith(path.resolve(dir))) {
+    response.writeHead(403, { "Content-Type": "text/html" });
+    response.end("Forbidden", "utf-8");
+    return;
+  }
 
   const extname = String(path.extname(filePath)).toLowerCase();
   const mime = mimeTypes[extname];


### PR DESCRIPTION
Potential fix for [https://github.com/ReconnectedCC/ninja-catcher/security/code-scanning/1](https://github.com/ReconnectedCC/ninja-catcher/security/code-scanning/1)

To fix the problem, we need to ensure that the constructed `filePath` is contained within a safe root directory. This can be achieved by normalizing the path using `path.resolve` and then checking that the normalized path starts with the root directory. If the path is not within the root directory, we should return a 403 Forbidden response.

1. Normalize the `filePath` using `path.resolve`.
2. Check if the normalized `filePath` starts with the root directory (`dir`).
3. If the check fails, return a 403 Forbidden response.
4. If the check passes, proceed with reading the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
