### PR TITLE
Fix broken hompage URL in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A web interface for ComputerCraft computers
 
 ## Getting started
- - Visit https://ninja.its-em.ma/
+ - Visit https://ninja.reconnected.cc/
  - Follow the instructions there
  - One can run `ninja edit <filename>` to edit a file remotely.
 


### PR DESCRIPTION
CNAME Cross-User Banned from Cloudflare. The new domain is reconnected.cc.

![image](https://github.com/user-attachments/assets/3eb430a2-be6e-47a1-89ba-04f43cc7a69a)
